### PR TITLE
Add MCQ management web app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
-# codex
-codex
+# MCQ Manager
+
+This project provides a simple web application to create multiple choice questionnaires (MCQ), mark them manually or via optical mark recognition (OMR) using Auto Multiple Choice (AMC), and export results to Excel.
+
+## Features
+
+- Create quizzes with up to 10 questions and four options per question.
+- Generate answer sheets that can be printed for students.
+- Mark completed sheets manually by clicking selected answers.
+- Placeholder function for integrating AMC to process scanned sheets.
+- Export results to Excel with index numbers, per-question grades, and total score.
+
+## Installation
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Run the application:
+
+```bash
+python app/app.py
+```
+
+The server will start at `http://127.0.0.1:5000`.
+
+## Notes
+
+- OMR processing requires [Auto Multiple Choice](https://www.auto-multiple-choice.net/) and is not fully implemented in this example. The `process_scanned_sheet` function should be adapted to call AMC commands and update results accordingly.
+- Results and quiz data are stored in `app/data/` as JSON files.

--- a/app/app.py
+++ b/app/app.py
@@ -1,0 +1,125 @@
+import os
+import json
+from flask import Flask, render_template, request, redirect, url_for, send_file
+from werkzeug.utils import secure_filename
+import pandas as pd
+
+app = Flask(__name__)
+DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
+QUIZ_FILE = os.path.join(DATA_DIR, 'quizzes.json')
+RESULTS_DIR = os.path.join(DATA_DIR, 'results')
+
+os.makedirs(RESULTS_DIR, exist_ok=True)
+
+
+def load_quizzes():
+    if os.path.exists(QUIZ_FILE):
+        with open(QUIZ_FILE, 'r') as f:
+            return json.load(f)
+    return {}
+
+
+def save_quizzes(data):
+    with open(QUIZ_FILE, 'w') as f:
+        json.dump(data, f, indent=2)
+
+
+@app.route('/')
+def index():
+    quizzes = load_quizzes()
+    return render_template('index.html', quizzes=quizzes)
+
+
+@app.route('/quiz/new', methods=['GET', 'POST'])
+def new_quiz():
+    if request.method == 'POST':
+        quizzes = load_quizzes()
+        qid = str(len(quizzes) + 1)
+        title = request.form['title']
+        questions = []
+        for i in range(1, 11):
+            text = request.form.get(f'q{i}')
+            if not text:
+                continue
+            options = [request.form.get(f'q{i}_o{j}') for j in range(1, 5)]
+            answer = request.form.get(f'q{i}_ans')
+            questions.append({
+                'text': text,
+                'options': options,
+                'answer': int(answer) if answer is not None else None
+            })
+        quizzes[qid] = {'title': title, 'questions': questions}
+        save_quizzes(quizzes)
+        return redirect(url_for('index'))
+    return render_template('new_quiz.html')
+
+
+@app.route('/sheet/<quiz_id>')
+def sheet(quiz_id):
+    quizzes = load_quizzes()
+    quiz = quizzes.get(quiz_id)
+    if not quiz:
+        return 'Quiz not found', 404
+    return render_template('sheet.html', quiz=quiz, quiz_id=quiz_id)
+
+
+@app.route('/mark/manual/<quiz_id>', methods=['GET', 'POST'])
+def manual_mark(quiz_id):
+    quizzes = load_quizzes()
+    quiz = quizzes.get(quiz_id)
+    if not quiz:
+        return 'Quiz not found', 404
+    if request.method == 'POST':
+        index_number = request.form['index']
+        answers = [int(request.form.get(f'q{i}', 0)) for i in range(len(quiz['questions']))]
+        score = 0
+        per_q = []
+        for i, ans in enumerate(answers):
+            correct = quiz['questions'][i]['answer']
+            if ans == correct:
+                score += 1
+                per_q.append(1)
+            else:
+                per_q.append(0)
+        result_file = os.path.join(RESULTS_DIR, f'{quiz_id}.json')
+        if os.path.exists(result_file):
+            with open(result_file, 'r') as f:
+                results = json.load(f)
+        else:
+            results = {}
+        results[index_number] = {'answers': answers, 'per_q': per_q, 'score': score}
+        with open(result_file, 'w') as f:
+            json.dump(results, f, indent=2)
+        return redirect(url_for('manual_mark', quiz_id=quiz_id))
+    return render_template('manual_mark.html', quiz=quiz, quiz_id=quiz_id)
+
+
+@app.route('/export/<quiz_id>')
+def export_results(quiz_id):
+    result_file = os.path.join(RESULTS_DIR, f'{quiz_id}.json')
+    if not os.path.exists(result_file):
+        return 'No results', 404
+    with open(result_file, 'r') as f:
+        results = json.load(f)
+    rows = []
+    for index, data in results.items():
+        row = {'Index': index}
+        for i, grade in enumerate(data['per_q'], start=1):
+            row[f'Q{i}'] = grade
+        row['Total'] = data['score']
+        rows.append(row)
+    df = pd.DataFrame(rows)
+    xls_path = os.path.join(RESULTS_DIR, f'{quiz_id}.xlsx')
+    df.to_excel(xls_path, index=False)
+    return send_file(xls_path, as_attachment=True)
+
+
+# Placeholder for scanned sheet processing via AMC
+def process_scanned_sheet(file_path, quiz_id):
+    """Process scanned sheet using AMC. This function is a placeholder."""
+    # Here you would call AMC commands to recognize the sheet
+    pass
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>MCQ Manager</title>
+</head>
+<body>
+    <h1>Quizzes</h1>
+    <a href="{{ url_for('new_quiz') }}">Create New Quiz</a>
+    <ul>
+    {% for qid, quiz in quizzes.items() %}
+        <li>
+            {{ quiz.title }} -
+            <a href="{{ url_for('sheet', quiz_id=qid) }}">Sheet</a> |
+            <a href="{{ url_for('manual_mark', quiz_id=qid) }}">Manual Mark</a> |
+            <a href="{{ url_for('export_results', quiz_id=qid) }}">Export</a>
+        </li>
+    {% endfor %}
+    </ul>
+</body>
+</html>

--- a/app/templates/manual_mark.html
+++ b/app/templates/manual_mark.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ quiz.title }} - Manual Marking</title>
+</head>
+<body>
+    <h1>{{ quiz.title }} - Manual Marking</h1>
+    <form method="post">
+        Index Number: <input type="text" name="index" required><br>
+        <table border="1" cellpadding="5">
+            <tr><th>Q#</th><th colspan="4">Select Answer</th></tr>
+            {% for q in quiz.questions %}
+            <tr>
+                <td>{{ loop.index }}</td>
+                {% for opt in q.options %}
+                    <td><input type="radio" name="q{{ loop.parent.index0 }}" value="{{ loop.index }}"></td>
+                {% endfor %}
+            </tr>
+            {% endfor %}
+        </table>
+        <button type="submit">Submit</button>
+    </form>
+</body>
+</html>

--- a/app/templates/new_quiz.html
+++ b/app/templates/new_quiz.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Create Quiz</title>
+</head>
+<body>
+    <h1>Create Quiz</h1>
+    <form method="post">
+        <label>Title: <input type="text" name="title" required></label><br>
+        {% for i in range(1,11) %}
+            <h3>Question {{ i }}</h3>
+            <input type="text" name="q{{ i }}" placeholder="Question text"><br>
+            {% for j in range(1,5) %}
+                Option {{ j }}: <input type="text" name="q{{ i }}_o{{ j }}"><br>
+            {% endfor %}
+            Correct option number: <input type="number" name="q{{ i }}_ans" min="1" max="4"><br>
+        {% endfor %}
+        <button type="submit">Save</button>
+    </form>
+</body>
+</html>

--- a/app/templates/sheet.html
+++ b/app/templates/sheet.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ quiz.title }} - Answer Sheet</title>
+</head>
+<body>
+    <h1>{{ quiz.title }} - Answer Sheet</h1>
+    <form>
+        Index Number: <input type="text" name="index" placeholder="e.g., 12345"><br>
+    </form>
+    <table border="1" cellpadding="5">
+        <tr><th>Q#</th><th colspan="4">Options</th></tr>
+        {% for q in quiz.questions %}
+        <tr>
+            <td>{{ loop.index }}</td>
+            {% for opt in q.options %}
+                <td>{{ opt }}</td>
+            {% endfor %}
+        </tr>
+        {% endfor %}
+    </table>
+    <p>Print this page and distribute to students.</p>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+pandas
+openpyxl


### PR DESCRIPTION
## Summary
- create Flask-based application for building MCQ quizzes
- allow manual marking of answer sheets and exporting results to Excel
- provide placeholder for AMC-based OMR processing
- add simple HTML templates
- ignore `__pycache__`

## Testing
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_686e7e2606488322863787c12b41f09a